### PR TITLE
Support of hash of zram_generator::zram instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ zram_generator::zram{'zram1':
 
 This will create a `/dev/zram1` device half the size of available RAM and activate it.
 
+## Hiera Example
+
+A set of `zram_generator::zram` can be loaded from hiera:
+
+```yaml
+zram_generator::zrams:
+  zram0:
+    fs_type: 'ext4'
+    mount_point: '/run/mount'
+  zram1:
+    zram_size: 1024
+```
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,6 +35,7 @@ The following parameters are available in the `zram_generator` class:
 
 * [`install_defaults`](#-zram_generator--install_defaults)
 * [`manage_defaults_package`](#-zram_generator--manage_defaults_package)
+* [`zrams`](#-zram_generator--zrams)
 
 ##### <a name="-zram_generator--install_defaults"></a>`install_defaults`
 
@@ -51,6 +52,14 @@ Data type: `Boolean`
 whether the zram-generator-defaults package should be managed
 
 Default value: `$facts['os']['name'] != 'Archlinux'`
+
+##### <a name="-zram_generator--zrams"></a>`zrams`
+
+Data type: `Stdlib::CreateResources`
+
+Hash of zram_generator::zram instances to expand from hiera.
+
+Default value: `{}`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,10 +2,12 @@
 # @see https://github.com/systemd/zram-generator
 # @param install_defaults Controls if the package 'zram-generator-defaults' be installed.
 # @param manage_defaults_package whether the zram-generator-defaults package should be managed
+# @param zrams Hash of zram_generator::zram instances to expand from hiera.
 #
 class zram_generator (
   Enum['installed', 'absent'] $install_defaults = 'absent',
   Boolean $manage_defaults_package = $facts['os']['name'] != 'Archlinux',
+  Stdlib::CreateResources $zrams = {},
 ) {
   contain zram_generator::install
   contain zram_generator::config
@@ -14,4 +16,10 @@ class zram_generator (
   Class['zram_generator::install']
   -> Class['zram_generator::config']
   -> Class['zram_generator::service']
+
+  $zrams.each |$name, $resource| {
+    zram_generator::zram { $name:
+      * => $resource,
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.18.0 < 10.0.0"
+      "version_requirement": ">= 8.5.0 < 10.0.0"
     }
   ],
   "tags": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,7 @@ describe 'zram_generator' do
         it { is_expected.to contain_exec('generate_zram_units').with_refreshonly(true) }
         it { is_expected.to contain_file('/usr/lib/systemd/zram-generator.conf.d').with_ensure('directory') }
         it { is_expected.to contain_package('zram-generator').with_ensure('installed') }
+        it { is_expected.to have_zram_generator__zram_resource_count(0) }
 
         if facts[:os]['name'] == 'Archlinux'
           it { is_expected.not_to contain_package('zram-generator-defaults') }
@@ -53,6 +54,35 @@ describe 'zram_generator' do
           end
 
           it { is_expected.not_to contain_package('zram-generator-defaults') }
+        end
+
+        context 'with a hash of zrams specified' do
+          let :params do
+            {
+              zrams: {
+                'zram0' => {
+                  'fs_type'     => 'ext4',
+                  'mount_point' => '/run/mount',
+                },
+                'zram1' => {
+                  'zram_size' => 1024,
+                },
+              },
+            }
+          end
+
+          it {
+            is_expected.to contain_zram_generator__zram('zram0').
+              with_fs_type('ext4').
+              with_mount_point('/run/mount')
+          }
+
+          it {
+            is_expected.to contain_zram_generator__zram('zram1').
+              with_zram_size('1024')
+          }
+
+          it { is_expected.to have_zram_generator__zram_resource_count(2) }
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description

Support a new parameter `zrams` on the main class to expand a hash of `zram_generator::zram` instances from hiera.

For example:

```yaml
zram_generator::zrams:
  zram0:
    fs_type: 'ext4'
    mount_point: '/run/mount'
  zram1:
    zram_size: 1024
```

Change requires at least puppetlabs-stdlib v8.5.0 to provide the `Stdlib::CreateResources` type.


#### This Pull Request (PR) fixes the following issues

Fixes #18 

